### PR TITLE
add filename substitution to args

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -32,6 +32,9 @@ export function executeFile(
         notUsePip = true
         return arg.replace(/%text/g, input.toString())
       }
+      if (/%filename/.test(arg)) {
+        return arg.replace(/%filename/g, path.basename(fpath))
+      }
       if (/%file/.test(arg)) {
         notUsePip = true
         return arg.replace(/%file/g, fpath.toString())


### PR DESCRIPTION
This adds `%filename%` substitution to `args`, to support the usage of `eslint_d` / `eslint` with `prettier-eslint`, which needs a filename when `--stdin` is used.

Sample coc.nvim configuration with `eslint_d`:

```json
{
   "languageserver":{
      "dls":{
         "command":"diagnostic-languageserver",
         "args":[
            "--stdio"
         ],
         "rootPatterns":[
            ".git"
         ],
         "cwd":"./",
         "filetypes":[
            "javascript",
            "javascriptreact",
            "typescript",
            "typescriptreact"
         ],
         "initializationOptions":{
            "linters":{
               "eslint":{
                  "command":"/usr/bin/eslint_d",
                  "rootPatterns":[
                     ".git"
                  ],
                  "debounce":100,
                  "args":[
                     "-c",
                     "/my/eslint/config.js",
                     "--stdin",
                     "--no-color",
                     "--stdin-filename",
                     "%filename"
                  ],
                  "offsetLine":0,
                  "offsetColumn":0,
                  "sourceName":"eslint",
                  "formatLines":1,
                  "formatPattern":[
                     "^\\s*(\\d+):(\\d+)\\s+([^ ]+)\\s+(.*?)\\s+([^ ]+)$",
                     {
                        "line":1,
                        "column":2,
                        "message":[
                           4,
                           " [",
                           5,
                           "]"
                        ],
                        "security":3
                     }
                  ],
                  "securities":{
                     "error":"error",
                     "warning":"warning"
                  }
               }
            },
            "formatters":{
               "eslint":{
                  "command":"/usr/bin/eslint_d",
                  "args":[
                     "-c",
                     "/my/eslint/config.js",
                     "--stdin",
                     "--no-color",
                     "--fix-to-stdout",
                     "--stdin-filename",
                     "%filename"
                  ],
                  "isStdout":true
               }
            },
            "filetypes":{
               "javascript":[
                  "eslint"
               ],
               "javascriptreact":[
                  "eslint"
               ],
               "typescript":[
                  "eslint"
               ],
               "typescriptreact":[
                  "eslint"
               ]
            },
            "formatFiletypes":{
               "javascript":"eslint",
               "javascriptreact":"eslint",
               "typescript":"eslint",
               "typescriptreact":"eslint"
            }
         }
      }
   }
}
```