### PR TITLE
Quality of life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ languageserver config:
       "error": "error",                              // [key: string]?: "error" | "warning" | "info" | "hint"
       "warning": "warning",
       "note": "info"
-    }
+    },
+    "requiredFiles": [                               // only run linter if any of these files exist. option
+      ".shellcheckrc",
+      "shellcheckrc"
+    ]
   }
 }
 ```
@@ -97,6 +101,10 @@ languageserver config:
     "rootPatterns": [],                        // root patterns, default empty array
     "isStdout": true,                          // use stdout output, default true
     "isStderr": false,                         // use stderr output, default false
+    "doesWriteToFile": false,                  // use if formatter doesn't support stdio. should be paired with `%file`
+    "requiredFiles": [                         // only run formatter if any of these files exist. optional
+      ".run_dartfmt",
+    ]
   }
 ```
 
@@ -112,9 +120,10 @@ languageserver config:
 
 `args: ["%text", "%filename", "%file"]`
 
-- `%filename` will replace with file name
+- `%filename` will replace with basename of file
 - `%text` will replace with file content
-- `%file` will replace with file name and not use stdio
+- `%file` will replace with full path to the file and not use stdio
+- `%filepath` will replace with full path to the file
 
 ## How to config a new linter
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -22,6 +22,7 @@ export interface ILinterConfig {
   securities?: ISecurities
   offsetLine?: number
   offsetColumn?: number
+  requiredFiles?: string[]
 }
 
 // config of per formatter
@@ -32,6 +33,7 @@ export interface IFormatterConfig {
   isStdout?: boolean
   isStderr?: boolean
   doesWriteToFile?: boolean
+  requiredFiles?: string[]
 }
 
 // initializationOptions config

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -31,6 +31,7 @@ export interface IFormatterConfig {
   rootPatterns?: string[] | string
   isStdout?: boolean
   isStderr?: boolean
+  doesWriteToFile?: boolean
 }
 
 // initializationOptions config

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -33,7 +33,7 @@ export function executeFile(
         return arg.replace(/%text/g, input.toString())
       }
       if (/%filepath/.test(arg)) {
-        return arg.replace(/%filename/g, fpath)
+        return arg.replace(/%filepath/g, fpath)
       }
       if (/%filename/.test(arg)) {
         return arg.replace(/%filename/g, path.basename(fpath))

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -32,12 +32,15 @@ export function executeFile(
         notUsePip = true
         return arg.replace(/%text/g, input.toString())
       }
+      if (/%filepath/.test(arg)) {
+        return arg.replace(/%filename/g, fpath)
+      }
       if (/%filename/.test(arg)) {
         return arg.replace(/%filename/g, path.basename(fpath))
       }
       if (/%file/.test(arg)) {
         notUsePip = true
-        return arg.replace(/%file/g, fpath.toString())
+        return arg.replace(/%file/g, fpath)
       }
       return arg
     })

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -20,7 +20,7 @@ export function executeFile(
   stderr: string
 }> {
   return new Promise((resolve, reject) => {
-    const fpath = VscUri.parse(textDocument.uri).path
+    const fpath = VscUri.parse(textDocument.uri).fsPath
 
     let stdout = ''
     let stderr = ''

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -110,3 +110,13 @@ export async function findCommand(command: string, workDir: string) {
   }
   return command
 }
+
+export function checkAnyFileExists(workDir: string, testPaths: string[]) {
+  for (const testPath of testPaths) {
+    if (fs.existsSync(path.join(workDir , testPath))) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -5,15 +5,12 @@ import {
   IConnection,
 } from 'vscode-languageserver';
 import VscUri from 'vscode-uri';
-import findup from 'findup';
-import path from 'path';
-import fs from 'fs';
 import { Subscription, Subject, from, timer } from 'rxjs';
 import { filter, switchMap, map } from 'rxjs/operators';
 
 import { waitMap } from '../common/observable';
 import { ILinterConfig, SecurityKey } from '../common/types';
-import { executeFile, pcb, findWorkDirectory, findCommand, checkAnyFileExists } from '../common/util';
+import { executeFile, findWorkDirectory, findCommand, checkAnyFileExists } from '../common/util';
 import HunkStream from '../common/hunkStream';
 import logger from '../common/logger';
 

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -13,7 +13,7 @@ import { filter, switchMap, map } from 'rxjs/operators';
 
 import { waitMap } from '../common/observable';
 import { ILinterConfig, SecurityKey } from '../common/types';
-import { executeFile, pcb, findWorkDirectory, findCommand } from '../common/util';
+import { executeFile, pcb, findWorkDirectory, findCommand, checkAnyFileExists } from '../common/util';
 import HunkStream from '../common/hunkStream';
 import logger from '../common/logger';
 
@@ -87,6 +87,13 @@ async function handleLinter (
       VscUri.parse(textDocument.uri).path,
       rootPatterns,
     )
+
+    if (config.requiredFiles && config.requiredFiles.length) {
+      if (!checkAnyFileExists(workDir, config.requiredFiles)) {
+        return diagnostics
+      }
+    }
+
     const cmd = await findCommand(command, workDir)
     const {
       stdout = '',

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -81,7 +81,7 @@ async function handleLinter (
   }
   try {
     const workDir = await findWorkDirectory(
-      VscUri.parse(textDocument.uri).path,
+      VscUri.parse(textDocument.uri).fsPath,
       rootPatterns,
     )
 

--- a/src/handles/handleFormat.ts
+++ b/src/handles/handleFormat.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import { TextEdit, TextDocument, CancellationToken, Range, Position } from 'vscode-languageserver';
 import VscUri from 'vscode-uri';
 
@@ -38,7 +39,9 @@ async function handleFormat(
     }
   )
   let output = '';
-  if (isStdout === undefined && isStderr === undefined) {
+  if (config.doesWriteToFile) {
+    output = fs.readFileSync(VscUri.parse(textDocument.uri).fsPath, 'utf8')
+  } else if (isStdout === undefined && isStderr === undefined) {
     output = stdout
   } else {
     if (isStdout) {

--- a/src/handles/handleFormat.ts
+++ b/src/handles/handleFormat.ts
@@ -28,7 +28,8 @@ async function handleFormat(
   const cmd = await findCommand(command, workDir)
   const {
     stdout = '',
-    stderr = ''
+    stderr = '',
+    code
   } = await executeFile(
     new HunkStream(text),
     textDocument,
@@ -39,7 +40,9 @@ async function handleFormat(
     }
   )
   let output = '';
-  if (config.doesWriteToFile) {
+  if (code > 0) {
+    output = text
+  } else if (config.doesWriteToFile) {
     output = fs.readFileSync(VscUri.parse(textDocument.uri).fsPath, 'utf8')
   } else if (isStdout === undefined && isStderr === undefined) {
     output = stdout

--- a/src/handles/handleFormat.ts
+++ b/src/handles/handleFormat.ts
@@ -22,7 +22,7 @@ async function handleFormat(
     args = [],
   } = config
   const workDir = await findWorkDirectory(
-    VscUri.parse(textDocument.uri).path,
+    VscUri.parse(textDocument.uri).fsPath,
     rootPatterns
   )
 

--- a/src/handles/handleFormat.ts
+++ b/src/handles/handleFormat.ts
@@ -61,7 +61,7 @@ async function handleFormat(
       output += stderr
     }
   }
-  return await next(output)
+  return next(output)
 }
 
 
@@ -78,7 +78,7 @@ export async function formatDocument(
       if (token.isCancellationRequested) {
         return
       }
-      return await handleFormat(config, textDocument, text, res)
+      return handleFormat(config, textDocument, text, res)
     }
   }, async (text: string) => text)
 

--- a/src/handles/handleFormat.ts
+++ b/src/handles/handleFormat.ts
@@ -3,7 +3,7 @@ import { TextEdit, TextDocument, CancellationToken, Range, Position } from 'vsco
 import VscUri from 'vscode-uri';
 
 import { IFormatterConfig } from '../common/types';
-import { findWorkDirectory, findCommand, executeFile } from '../common/util';
+import { findWorkDirectory, findCommand, executeFile, checkAnyFileExists } from '../common/util';
 import HunkStream from '../common/hunkStream';
 
 type Handle = (text: string) => Promise<string>
@@ -25,6 +25,13 @@ async function handleFormat(
     VscUri.parse(textDocument.uri).path,
     rootPatterns
   )
+
+  if (config.requiredFiles && config.requiredFiles.length) {
+    if (!checkAnyFileExists(workDir, config.requiredFiles)) {
+      return next(text)
+    }
+  }
+
   const cmd = await findCommand(command, workDir)
   const {
     stdout = '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ connection.onDocumentFormatting(async (
   if (formatterConfigs.length === 0) {
     return
   }
-  return await formatDocument(formatterConfigs, doc, token)
+  return formatDocument(formatterConfigs, doc, token)
 })
 
 // lsp start


### PR DESCRIPTION
Really loving this library, paired with coc.nvim we've got great coverage with linters, formatters, and language servers.

When playing with a few linters, I noticed some issues:

- not all fixers support stdin/stdout communication
- when a formatter fails, the file is replaced with the errors output
- there should be a way to run linters / formatters only when certain files exist

This PR handles those situations.