### PR TITLE
JSON support and endLine / endColumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,35 @@ languageserver config:
     "offsetLine": 0,                                 // offsetline
     "offsetColumn": 0,                               // offsetColumn
     "sourceName": "shellcheck",                      // source name
+
+    // Using regular expressions:
     "formatLines": 1,                                // how much lines for formatPattern[0] to match
     "formatPattern": [
       "^[^:]+:(\\d+):(\\d+):\\s+([^:]+):\\s+(.*)$",  // line match pattern (javascript regex)
       {
         "line": 1,                                   // diagnostic line use match group 1
         "column": 2,                                 // diagnostic column use match group 2
+        "endLine": 1,                                // diagnostic end line use match group 1. Will default to group from `line`
+        "endColumn": 2,                              // diagnostic end column use match group 2. Will default to group from `column`
         "message": [4],                              // message to display use match group 4
         "security": 3                                // security to use match group 3, ignore if linter do not support security
       }
     ],
+
+    // Using JSON:
+    "parseJson": {
+      "errorsRoot": "[0].messages",                 // dot separated path. Will default to whatever JSON is output
+                                                     // for more information see examples at https://lodash.com/docs/#get
+
+      // All of these support lodash.get syntax.
+      "line": "line",                                // property that contains the `line`
+      "column": "column",                            // property that contains the `column`
+      "endLine": "endLine",                          // property that contains the `endLine`. Will default to `line`
+      "endColumn": "endColumn",                      // property that contains the `endColumn`. Will default to `column`
+      "security": "severity"                         // property that contains the `security`
+      "message": "${message} [${code}]",             // message to display
+    },
+
     "securities": {                                  // security keys, ignore if linter do not support security
       "error": "error",                              // [key: string]?: "error" | "warning" | "info" | "hint"
       "warning": "warning",
@@ -118,7 +137,7 @@ languageserver config:
 
 ## Args additional syntax
 
-`args: ["%text", "%filename", "%file"]`
+`args: ["%text", "%filename", "%file", "%filepath"]`
 
 - `%filename` will replace with basename of file
 - `%text` will replace with file content

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
   },
   "dependencies": {
     "findup": "^0.1.5",
+    "lodash": "^4.17.15",
     "rxjs": "^6.4.0",
     "tslib": "^1.9.3",
     "vscode-languageserver": "^5.3.0-next.1",
     "vscode-uri": "^1.0.6"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.149",
     "@types/node": "^11.11.3",
     "typescript": "^3.3.3333"
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -16,6 +16,8 @@ export interface ILinterConfig {
   formatPattern: [string, {
     line: number,
     column: number,
+    endLine?: number,
+    endColumn?: number,
     message: Array<number|string> | number,
     security: number
   }]
@@ -23,6 +25,21 @@ export interface ILinterConfig {
   offsetLine?: number
   offsetColumn?: number
   requiredFiles?: string[]
+  parseJson?: {
+    // Dot separated path. If empty, simply use the root.
+    errorsRoot?: string | string[]
+
+    line: string
+    column: string
+
+    // If left out, just use line / column
+    endLine?: string
+    endColumn?: string
+
+    // Will be parsed from the error object.
+    message: string
+    security: string
+  },
 }
 
 // config of per formatter

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -42,6 +42,15 @@ export interface ILinterConfig {
   },
 }
 
+export interface ILinterResult {
+  security: string
+  line: string | number
+  column: string | number
+  endLine?: string | number
+  endColumn?: string | number
+  message: string
+}
+
 // config of per formatter
 export interface IFormatterConfig {
   command: string

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -223,6 +223,10 @@ async function handleLinter (
         output += stderr
       }
     }
+
+    return config.parseJson
+      ? handleLinterJson(output, config)
+      : handleLinterRegex(output, config)
   } catch (error) {
     logger.error(`[${textDocument.languageId}] diagnostic handle fail: ${error.message}`)
   }

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -180,7 +180,7 @@ async function handleLinter (
     isStdout,
     isStderr,
   } = config
-  let diagnostics: Diagnostic[] = [];
+  const diagnostics: Diagnostic[] = [];
   // verify params
   if (!command || !sourceName) {
     logger.error(`[${textDocument.languageId}] missing config`)

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -228,7 +228,7 @@ async function handleLinter (
       ? handleLinterJson(output, config)
       : handleLinterRegex(output, config)
   } catch (error) {
-    logger.error(`[${textDocument.languageId}] diagnostic handle fail: ${error.message}`)
+    logger.error(`[${textDocument.languageId}] diagnostic handle fail: [${sourceName}] ${error.message}`)
   }
   return diagnostics
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/node@^11.11.3":
   version "11.11.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.3.tgz#7c6b0f8eaf16ae530795de2ad1b85d34bf2f5c58"
@@ -23,6 +28,11 @@ findup@^0.1.5:
   dependencies:
     colors "~0.6.0-1"
     commander "~2.1.0"
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 rxjs@^6.4.0:
   version "6.4.0"


### PR DESCRIPTION
Closes https://github.com/iamcco/diagnostic-languageserver/issues/12.

Adds support for linters that output JSON. Most will include more detailed data than their normal CLI output.

Adds support for `endLine` and `endColumn`. This makes for even better diagnostics when supported:

![trimmed Screen Recording 2019-12-05 at 1 06 46 AM mov](https://user-images.githubusercontent.com/4729/70205880-033b2980-16fc-11ea-80a5-588d88404957.gif)

Here's my updated eslint / shellcheck / stylelint configs:

```json
    "eslint": {
      "command": "./node_modules/.bin/eslint",
      "rootPatterns": [
        ".git"
      ],
      "debounce": 100,
      "args": [
        "--stdin",
        "--stdin-filename",
        "%filepath",
        "--format",
        "json"
      ],
      "sourceName": "eslint",
      "parseJson": {
        "errorsRoot": "[0].messages",
        "line": "line",
        "column": "column",
        "endLine": "endLine",
        "endColumn": "endColumn",
        "message": "${message} [${ruleId}]",
        "security": "severity"
      },
      "securities": {
        "2": "error",
        "1": "warning"
      }
    },

    "shellcheck": {
      "command": "shellcheck",
      "debounce": 100,
      "args": [
        "--format",
        "json",
        "-"
      ],
      "sourceName": "shellcheck",
      "parseJson": {
        "line": "line",
        "column": "column",
        "endLine": "endLine",
        "endColumn": "endColumn",
        "message": "${message} [${code}]",
        "security": "level"
      },
      "securities": {
        "error": "error",
        "warning": "warning",
        "info": "info",
        "style": "hint"
      }
    },

    "stylelint": {
      "command": "./node_modules/.bin/stylelint",
      "rootPatterns": [
        ".git"
      ],
      "debounce": 100,
      "args": [
        "--formatter",
        "json",
        "--stdin-filename",
        "%filepath"
      ],
      "sourceName": "stylelint",
      "parseJson": {
        "errorsRoot": "[0].warnings",
        "line": "line",
        "column": "column",
        "message": "${text}",
        "security": "severity"
      },
      "securities": {
        "error": "error",
        "warning": "warning"
      }
    }
```