### PR TITLE
Fix findWorkingDirectory() support both files and directories and process rootPatterns in order

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -87,12 +87,28 @@ export async function findWorkDirectory(
   const dirname = path.dirname(filePath)
   let patterns = [].concat(rootPatterns)
   try {
-    const dir = await findUp(patterns, {
-      cwd: dirname
-    });
+    for(const pattern of patterns) {
+      // attempt to match for directory patterns
+      let dirMatchPath = await findUp(pattern, {
+        cwd: dirname,
+        type: "directory",
+      })
 
-    if (dir && dir !== '/') {
-      return dir
+      if (!dirMatchPath) {
+        // if no directories were found, attempt to match file patterns
+        const fileMatchPath = await findUp(pattern, {
+          cwd: dirname,
+          type: "file",
+        })
+
+        if (fileMatchPath) {
+          dirMatchPath = path.dirname(fileMatchPath)
+        }
+      }
+
+      if (dirMatchPath && dirMatchPath !== "/") {
+        return dirMatchPath
+      }
     }
   } catch (err) {
     // do nothing on error

--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -164,6 +164,8 @@ async function handleLinter (
       rootPatterns,
     )
 
+    logger.info(`found working directory ${workDir}`)
+
     if (config.requiredFiles && config.requiredFiles.length) {
       if (!checkAnyFileExists(workDir, config.requiredFiles)) {
         return diagnostics


### PR DESCRIPTION
It turns out that `find-up` does not match both files and directories and only files by default so we need to do two lookups.

- [x] respect rootPattern resolution order
- [x] fix support for matching directories