### PR TITLE
Add log level control flag to reduce log noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ languageserver config:
   "languageserver": {
     "dls": {
       "command": "diagnostic-languageserver",
-      "args": ["--stdio"],
+      "args": ["--stdio", "--log-level", "2"],
       "filetypes": [ "sh", "email" ], // filetypes that you want to enable this lsp
       "initializationOptions": {
         "linters": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "diagnostic-languageserver": "./bin/index.js"
   },
   "dependencies": {
+    "commander": "^5.1.0",
     "find-up": "^4.1.0",
     "lodash": "^4.17.15",
     "rxjs": "^6.5.5",

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,29 +1,31 @@
-import { IConnection } from 'vscode-languageserver';
+import { IConnection, MessageType } from 'vscode-languageserver';
 
 let connection: IConnection
+let level: MessageType
 
 export default {
-  init: (con: IConnection) => {
+  init: (con: IConnection, lev: MessageType) => {
     connection = con
-  },
-  log: (message: string) => {
-    if (connection) {
-      connection.console.log(message)
-    }
+    level = lev
   },
   error: (message: string) => {
-    if (connection) {
+    if (connection && level >= MessageType.Error) {
       connection.console.error(message)
     }
   },
   warn: (message: string) => {
-    if (connection) {
+    if (connection && level >= MessageType.Warning) {
       connection.console.warn(message)
     }
   },
   info: (message: string) => {
-    if (connection) {
+    if (connection && level >= MessageType.Info) {
       connection.console.info(message)
+    }
+  },
+  log: (message: string) => {
+    if (connection && level >= MessageType.Log) {
+      connection.console.log(message)
     }
   },
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ let logLevel: MessageType = MessageType.Warning
 if (options.logLevel) {
   logLevel = parseInt(options.logLevel, 10) as any;
   if (logLevel && (logLevel < 1 || logLevel > 4)) {
-    console.error("Invalid `--log-level " + logLevel + "`. Falling back to `warn` level.")
-    logLevel = MessageType.Warning
+    console.error("Invalid `--log-level " + logLevel + "`. Falling back to `log` level.")
+    logLevel = MessageType.Log
   }
 }
 


### PR DESCRIPTION
The log messages are quite noisy, especially the low-level ones like "match string:" and "match result:" in `handleDiagnostic.ts`.

This PR sets the default log level to `warn` and adds a CLI flag to configure this. It also adds some CLI parsing, so running `diagnostic-languageserver --help` will now display the CLI options.