### PR TITLE
Support %dirname in additional args syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,13 @@ languageserver config:
 
 ## Args additional syntax
 
-`args: ["%text", "%filename", "%file", "%filepath", "%tempfile"]`
+`args: ["%text", "%filename", "%file", "%filepath", "%dirname", "%tempfile"]`
 
 - `%filename` will replace with basename of file
 - `%text` will replace with file content
 - `%file` will replace with full path to the file and not use stdio
 - `%filepath` will replace with full path to the file
+- `%dirname` will replace with dirname of file
 - `%tempfile` will replace with the full path to a temporary file written with the contents
   of the document and not use stdio; this file will automatically be deleted when the
   command completes

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -39,6 +39,9 @@ export async function executeFile(
     if (/%filename/.test(arg)) {
       return arg.replace(/%filename/g, path.basename(fpath))
     }
+    if (/%dirname/.test(arg)) {
+      return arg.replace(/%dirname/g, path.dirname(fpath))
+    }
     if (/%file/.test(arg)) {
       usePipe = false
       return arg.replace(/%file/g, fpath)


### PR DESCRIPTION
Support %dirname in additional args syntax. This is useful to pass the golangci-linter the directory of the file.

Closes https://github.com/iamcco/diagnostic-languageserver/issues/53