### PR TITLE
Filter out ranges with no line number

### DIFF
--- a/src/handles/handleDiagnostic.ts
+++ b/src/handles/handleDiagnostic.ts
@@ -132,7 +132,9 @@ function handleLinterJson(currentSourceName: string, output: string, config: ILi
   ? lodashGet(JSON.parse(output), errorsRoot, [])
     : JSON.parse(output)
 
-  return resultsFromJson.map<ILinterResult>(jsonObject => {
+  return resultsFromJson.filter(jsonObject => {
+    return null !== lodashGet(jsonObject, line)
+  }).map<ILinterResult>(jsonObject => {
     return {
       sourceName: sourceName ? lodashGet(jsonObject, sourceName) : currentSourceName,
       security: lodashGet(jsonObject, security),


### PR DESCRIPTION
Filter out unusable result like such below:
```json
{
    "totals": {
        "errors": 0,
        "file_errors": 1
    },
    "files": {
        "/home/x/y/z.php": {
            "errors": 1,
            "messages": [
                {
                    "message": "Internal error: Unexpected type PHPStan\\Type\\ObjectType during method call one at line 58\nRun PHPStan with --debug option and post the stack trace to:\nhttps://github.com/phpstan/phpstan/issues/new?template=Bug_report.md",
                    "line": null,
                    "ignorable": false
                }
            ]
        }
    },
    "errors": []
}
```