### PR TITLE
feat: allow to run linter only on file save

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ languageserver config:
     "isStdout": true,                                // use stdout output, default true
     "isStderr": false,                               // use stderr output, default false
     "debounce": 100,                                 // debounce time
+    "onSaveOnly": false,                             // linter is triggered only when file is saved
     "args": [ "--format=gcc", "-"],                  // args
     "offsetLine": 0,                                 // offsetline
     "offsetColumn": 0,                               // offsetColumn

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -10,6 +10,7 @@ export interface ILinterConfig {
   isStdout?: boolean
   isStderr?: boolean
   debounce?: number
+  onSaveOnly?: boolean
   args?: Array<string|number>
   sourceName: string
   formatLines?: number


### PR DESCRIPTION
Some linters are really slow, this adds an option to run them only when
the file is saved.